### PR TITLE
Added udemy course links for some subject, NA for missing courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 #### 2. It will take 3-6 Months to learn this skills depends on your efforts and time given to the course.
 #### 3. If you know any of the skills already then you can still learn the rest of it.
 #### 4. If you think i'm missing any of the skills please add it and make a pull request
+
 Subjects | Resource | Duration | Effort | Frequency | Prerequisites | Free Udemy Course|
 :-- | :--: | :--: | :--: | :--: | :--: | :--: |
 C Programming | [Videos](https://www.youtube.com/watch?v=KJgsSFOSQv0) [Books](https://drive.google.com/drive/u/0/folders/1QGb6pUzv1JiRIyNPMcYJOxDjnqhvoCCn)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
@@ -32,11 +33,12 @@ Linux | [Videos](https://www.youtube.com/watch?v=v_1zB2WNN14) [Books](https://dr
 
 # Android/IOS Developer
 ### Note:- 
-#### 1. Learn Java and xml first Kotlin is not compulsary for Android Developement.
+#### 1. Learn Java and xml first. Kotlin is not compulsary for Android Developement.
 #### 2. Learn Flutter & Drat for both Android as well as IOS.
 #### 3. It will take 8-10 Months to learn this skills depends on your efforts and time given to the course.
 #### 4. If you know any of the skills already then you can still learn the rest of it.
 #### 5. If you think i'm missing any of the skills please add it and make a pull request
+
 Subjects | Resource | Duration | Effort | Frequency | Prerequisites | Free Udemy Course|
 :-- | :--: | :--: | :--: | :--: | :--: | :--: |
 JAVA Programming | [Videos](https://www.youtube.com/watch?v=eIrMbAQSU34) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 6-8 weeks | 2-5 hours/week | 1 Topic a day | Basic Programming | [Link](https://www.udemy.com/course/java-tutorial/)
@@ -50,31 +52,33 @@ Dart | [Videos](https://www.youtube.com/watch?v=Ej_Pcr4uC2Q) [Books](https://dri
 
 # Full Stack Developer
 ### Note:- 
-#### 1. Learn HTML/CSS and Javascript first Node.js is not compulsary for Full Stack Developer.
+#### 1. Learn HTML/CSS and Javascript first. Node.js is not compulsary for Full Stack Developer.
 #### 2. It will take 12-16 Months to learn this skills depends on your efforts and time given to the course.
 #### 3. If you know any of the skills already then you can still learn the rest of it.
 #### 4. If you think i'm missing any of the skills please add it and make a pull request
+
 Subjects | Resource | Duration | Effort | Frequency | Prerequisites | Free Udemy Course|
 :-- | :--: | :--: | :--: | :--: | :--: | :--: |
 HTML & CSS | [Videos](https://www.youtube.com/watch?v=pQN-pnXPaVg) [Books](https://drive.google.com/drive/u/0/folders/1VKzclp5MQ9_FD9foZDZ5ROybqWitVo1V) | 4-6 weeks | 2-5 hours/week | 1 Topic a day  | none | [Link](https://www.udemy.com/course/html-and-css-for-beginners-crash-course-learn-fast-easy/)
 Javascript | [Videos](https://www.youtube.com/watch?v=PkZNo7MFNFg) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 5-6 weeks | 2-5 hours/week | 1 Topic a day | Basic Programming | [Link](https://www.udemy.com/course/modern-javascript-course/)
-SQL | [Videos](https://www.youtube.com/watch?v=HXV3zeQKqGY) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Basic Database | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Node.js | [Videos](https://www.youtube.com/watch?v=RLtyhwFtXQA) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-5 weeks | 2-5 hours/week | 1 Topic a day | Basic Programming | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Git | [Videos](https://www.youtube.com/watch?v=xuB1Id2Wxak) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 1-2 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
+SQL | [Videos](https://www.youtube.com/watch?v=HXV3zeQKqGY) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Basic Database | [Link](https://www.udemy.com/course/sql-essentials-for-beginners/)
+Node.js | [Videos](https://www.youtube.com/watch?v=RLtyhwFtXQA) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-5 weeks | 2-5 hours/week | 1 Topic a day | Basic Programming | NA
+Git | [Videos](https://www.youtube.com/watch?v=xuB1Id2Wxak) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 1-2 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/git-expert-4-hours/)
 
 
 # Python-Web Developer
 ### Note:- 
 #### 1. Learn all the basics of Python and Advance Python concepts like OOP etc.
-#### 2. Learn Flask , Django, Cherrypy.
+#### 2. Learn Flask , Django or Cherrypy.
 #### 3. It will take 6-8 Months to learn this skills depends on your efforts and time given to the course.
 #### 4. If you know any of the skills already then you can still learn the rest of it.
 #### 5. If you think i'm missing any of the skills please add it and make a pull request
+
 Subjects | Resource | Duration | Effort | Frequency | Prerequisites | Free Udemy Course|
 :-- | :--: | :--: | :--: | :--: | :--: | :--: |
-Python | [Videos](https://www.youtube.com/watch?v=_uQrJ0TkZlc) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Basic Programming | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Flask | [Videos](https://www.youtube.com/watch?v=3mwFC4SHY-Y) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Python HTML&CSS | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Django | [Videos](https://www.youtube.com/watch?v=F5mRW0jo-U4) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Python HTML&CSS| [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
+Python | [Videos](https://www.youtube.com/watch?v=_uQrJ0TkZlc) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Basic Programming | [Link](https://www.udemy.com/course/learn-python-programming/)
+Flask | [Videos](https://www.youtube.com/watch?v=3mwFC4SHY-Y) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Python HTML&CSS | [Link](https://www.udemy.com/course/introduction-to-flask/)
+Django | [Videos](https://www.youtube.com/watch?v=F5mRW0jo-U4) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | Python HTML&CSS| [Link](https://www.udemy.com/course/learn-django-by-building-a-store-management-system/)
 
 
 # Data Scientist
@@ -84,10 +88,10 @@ Django | [Videos](https://www.youtube.com/watch?v=F5mRW0jo-U4) [Books](https://d
 #### 3. If you think i'm missing any of the skills please add it and make a pull request
 Subjects | Resource | Duration | Effort | Frequency | Prerequisites | Free Udemy Course|
 :-- | :--: | :--: | :--: | :--: | :--: | :--: |
-Statistics | [Videos](https://www.youtube.com/watch?v=74oUwKezFho) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
- Programming Language R / Python | [Videos](https://www.youtube.com/watch?v=ua-CiDNNj30) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
- Advanced Machine Learning (Deep Learning) | [Videos](https://www.youtube.com/watch?v=GwIo3gDZCVQ) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Big Data | [Videos](https://www.youtube.com/watch?v=1vbXmCrkT3Y) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
+Statistics | [Videos](https://www.youtube.com/watch?v=74oUwKezFho) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
+ Programming Language R / Python | [Videos](https://www.youtube.com/watch?v=ua-CiDNNj30) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
+ Advanced Machine Learning (Deep Learning) | [Videos](https://www.youtube.com/watch?v=GwIo3gDZCVQ) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
+Big Data | [Videos](https://www.youtube.com/watch?v=1vbXmCrkT3Y) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
 
 # DevOps Engineer
 ### Note:-
@@ -96,11 +100,11 @@ Big Data | [Videos](https://www.youtube.com/watch?v=1vbXmCrkT3Y) [Books](https:/
 #### 3. If you think i'm missing any of the skills please add it and make a pull request
 Subjects | Resource | Duration | Effort | Frequency | Prerequisites | Free Udemy Course|
 :-- | :--: | :--: | :--: | :--: | :--: | :--: |
-Docker | [Videos](https://www.youtube.com/watch?v=fqMOX6JJhGo) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Puppet | [Videos](https://www.youtube.com/watch?v=0yVJhb2VkVk) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Chef | [Videos](https://www.youtube.com/watch?v=JHoy3lDZOfY) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-Ansible | [Videos](https://www.youtube.com/watch?v=4nKW2eF-nIw) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
-kubernetes| [Videos](https://www.youtube.com/watch?v=F-p_7XaEC84) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | [Link](https://www.udemy.com/course/learn-c-programming-from-scratch/)
+Docker | [Videos](https://www.youtube.com/watch?v=fqMOX6JJhGo) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
+Puppet | [Videos](https://www.youtube.com/watch?v=0yVJhb2VkVk) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
+Chef | [Videos](https://www.youtube.com/watch?v=JHoy3lDZOfY) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
+Ansible | [Videos](https://www.youtube.com/watch?v=4nKW2eF-nIw) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
+kubernetes| [Videos](https://www.youtube.com/watch?v=F-p_7XaEC84) [Books](https://drive.google.com/drive/u/0/folders/1qEOF0Q0a795u-_SX8A-Jl6672LKr05bY)| 4-6 weeks | 2-5 hours/week | 1 Topic a day | none | NA
 
 
 # More Coming Soon:-


### PR DESCRIPTION
- [x] Changed the course links for following subjects
  - SQL
  - git
  - Python
  - Flask
  - django

- [x] NA, instead of `c programming links`, in other subjects, where free course was not found at the time

Fixes: #2 